### PR TITLE
Don't crash on error; Pretty-print help message

### DIFF
--- a/examples/overview.zig
+++ b/examples/overview.zig
@@ -8,7 +8,9 @@ pub fn main() !void {
     var args = try std.process.argsWithAllocator(gpa.allocator());
     defer args.deinit();
 
-    const result = flags.parse(&args, Overview, .{});
+    const result = flags.parse(&args, Overview, .{}) catch {
+        std.process.exit(1);
+    };
 
     try std.json.stringify(
         result,

--- a/src/console.zig
+++ b/src/console.zig
@@ -1,0 +1,208 @@
+const std = @import("std");
+
+pub const Color = enum(u8) {
+    Black,
+    Red,
+    Green,
+    Yellow,
+    Blue,
+    Magenta,
+    Cyan,
+    White,
+    // Use terminal defaults
+    Default,
+};
+
+pub const Style = enum(u8) {
+    Bold,
+    Italic,
+    Underline,
+    Blink,
+    FastBlink,
+    Reverse, // Invert the foreground and background colors
+    Hide,
+    Strike,
+};
+
+pub const TextStyle = struct {
+    fg_color: ?Color = null,
+    bg_color: ?Color = null,
+    bold: bool = false,
+    italic: bool = false,
+    underline: bool = false,
+    blink: bool = false,
+    fastblink: bool = false,
+    reverse: bool = false,
+    hide: bool = false,
+    strike: bool = false,
+};
+
+// ANSI terminal escape character
+pub const ansi = [1]u8{0x1b};
+
+// ANSI Reset command (clear formatting)
+pub const ansi_end = ansi ++ "[m";
+
+// ANSI cursor movements
+pub const move_up = ansi ++ "[{d}A";
+pub const move_down = ansi ++ "[{d}B";
+pub const move_right = ansi ++ "[{d}C";
+pub const move_left = ansi ++ "[{d}D";
+pub const move_setcol = ansi ++ "[{d}G";
+pub const move_home = ansi ++ "[0G";
+
+pub const set_col = ansi ++ "[{d}G";
+pub const set_row_col = ansi ++ "[{d};{d}H"; // Row, Column
+
+pub const save_position = ansi ++ "[s";
+pub const restore_position = ansi ++ "[u";
+
+// ANSI Clear Screen Command
+pub const clear_screen_end = ansi ++ "[0J"; // Clear from cursor to end of screen
+pub const clear_screen_beg = ansi ++ "[1J"; // Clear from cursor to beginning of screen
+pub const clear_screen = ansi ++ "[2J"; // Clear entire screen
+
+// ANSI Clear Line Command
+pub const clear_line_end = ansi ++ "[0K"; // Clear from cursor to end of line
+pub const clear_line_beg = ansi ++ "[1K"; // Clear from cursor to beginning of line
+pub const clear_line = ansi ++ "[2K"; // Clear entire line
+
+// ====================================================
+// ANSI display codes (colors, styles, etc.)
+// ----------------------------------------------------
+
+// Basic Background Colors
+pub const bg_black = ansi ++ "[40m";
+pub const bg_red = ansi ++ "[41m";
+pub const bg_green = ansi ++ "[42m";
+pub const bg_yellow = ansi ++ "[43m";
+pub const bg_blue = ansi ++ "[44m";
+pub const bg_magenta = ansi ++ "[45m";
+pub const bg_cyan = ansi ++ "[46m";
+pub const bg_white = ansi ++ "[47m";
+pub const bg_default = ansi ++ "[49m";
+
+// Basic Foreground Colors
+pub const fg_black = ansi ++ "[30m";
+pub const fg_red = ansi ++ "[31m";
+pub const fg_green = ansi ++ "[32m";
+pub const fg_yellow = ansi ++ "[33m";
+pub const fg_blue = ansi ++ "[34m";
+pub const fg_magenta = ansi ++ "[35m";
+pub const fg_cyan = ansi ++ "[36m";
+pub const fg_white = ansi ++ "[37m";
+pub const fg_default = ansi ++ "[39m";
+
+// Full 24-Bit RGB Coloring
+// Format strings which take 3 u8's for (r, g, b)
+pub const fg_rgb = ansi ++ "[38;2;{d};{d};{d}m";
+pub const bg_rgb = ansi ++ "[48;2;{d};{d};{d}m";
+
+// Typeface Formatting
+pub const text_bold = ansi ++ "[1m";
+pub const text_italic = ansi ++ "[3m";
+pub const text_underline = ansi ++ "[4m";
+pub const text_blink = ansi ++ "[5m";
+pub const text_fastblink = ansi ++ "[6m";
+pub const text_reverse = ansi ++ "[7m";
+pub const text_hide = ansi ++ "[8m";
+pub const text_strike = ansi ++ "[9m";
+
+pub const end_bold = ansi ++ "[22m";
+pub const end_italic = ansi ++ "[23m";
+pub const end_underline = ansi ++ "[24m";
+pub const end_blink = ansi ++ "[25m";
+pub const end_reverse = ansi ++ "[27m";
+pub const end_hide = ansi ++ "[28m";
+pub const end_strike = ansi ++ "[29m";
+
+pub fn getFgColor(color: Color) []const u8 {
+    return switch (color) {
+        .Black => fg_black,
+        .Red => fg_red,
+        .Green => fg_green,
+        .Yellow => fg_yellow,
+        .Blue => fg_blue,
+        .Cyan => fg_cyan,
+        .White => fg_white,
+        .Magenta => fg_magenta,
+        .Default => fg_default,
+    };
+}
+
+pub fn getBgColor(color: Color) []const u8 {
+    return switch (color) {
+        .Black => bg_black,
+        .Red => bg_red,
+        .Green => bg_green,
+        .Yellow => bg_yellow,
+        .Blue => bg_blue,
+        .Cyan => bg_cyan,
+        .White => bg_white,
+        .Magenta => bg_magenta,
+        .Default => bg_default,
+    };
+}
+
+/// Configure the terminal to start printing with the given foreground color
+pub fn startFgColor(stream: anytype, color: Color) void {
+    stream.print("{s}", .{getFgColor(color)}) catch unreachable;
+}
+
+/// Configure the terminal to start printing with the given background color
+pub fn startBgColor(stream: anytype, color: Color) void {
+    stream.print("{s}", .{getBgColor(color)}) catch unreachable;
+}
+
+/// Configure the terminal to start printing with the given (single) style
+pub fn startStyle(stream: anytype, style: Style) void {
+    switch (style) {
+        .Bold => stream.print(text_bold, .{}) catch unreachable,
+        .Italic => stream.print(text_italic, .{}) catch unreachable,
+        .Underline => stream.print(text_underline, .{}) catch unreachable,
+        .Blink => stream.print(text_blink, .{}) catch unreachable,
+        .FastBlink => stream.print(text_fastblink, .{}) catch unreachable,
+        .Reverse => stream.print(text_reverse, .{}) catch unreachable,
+        .Hide => stream.print(text_hide, .{}) catch unreachable,
+        .Strike => stream.print(text_strike, .{}) catch unreachable,
+    }
+}
+
+/// Configure the terminal to start printing one or more styles with color
+pub fn startStyles(stream: anytype, style: TextStyle) void {
+    if (style.bold) stream.print(text_bold, .{}) catch unreachable;
+    if (style.italic) stream.print(text_italic, .{}) catch unreachable;
+    if (style.underline) stream.print(text_underline, .{}) catch unreachable;
+    if (style.blink) stream.print(text_blink, .{}) catch unreachable;
+    if (style.fastblink) stream.print(text_fastblink, .{}) catch unreachable;
+    if (style.reverse) stream.print(text_reverse, .{}) catch unreachable;
+    if (style.hide) stream.print(text_hide, .{}) catch unreachable;
+    if (style.strike) stream.print(text_strike, .{}) catch unreachable;
+
+    if (style.fg_color) |fg_color| {
+        startFgColor(stream, fg_color);
+    }
+
+    if (style.bg_color) |bg_color| {
+        startBgColor(stream, bg_color);
+    }
+}
+
+/// Reset all style in the terminal
+pub fn resetStyle(stream: anytype) void {
+    stream.print(ansi_end, .{}) catch unreachable;
+}
+
+/// Print the text using the given color
+pub fn printColor(stream: anytype, color: Color, comptime fmt: []const u8, args: anytype) void {
+    startFgColor(stream, color);
+    stream.print(fmt, args) catch unreachable;
+    resetStyle(stream);
+}
+
+/// Print the text using the given style description
+pub fn printStyled(stream: anytype, style: TextStyle, comptime fmt: []const u8, args: anytype) void {
+    startStyles(stream, style);
+    stream.print(fmt, args) catch unreachable;
+    resetStyle(stream);
+}

--- a/src/core.zig
+++ b/src/core.zig
@@ -83,13 +83,14 @@ pub fn parse(
     args: *ArgIterator,
     comptime Flags: type,
     comptime command_seq: []const u8,
+    comptime max_line_len: usize,
     trailing_handler: TrailingHandler,
 ) !Flags {
     const info = meta.info(Flags);
     const help_message: []const u8 = if (@hasDecl(Flags, "help"))
         Flags.help // must be a string
     else
-        comptime help.generate(Flags, info, command_seq);
+        comptime help.generate(Flags, info, command_seq, max_line_len);
 
     // If we error out, print the help message
     errdefer printHelp(help_message);
@@ -164,6 +165,7 @@ pub fn parse(
                     args,
                     cmd.type,
                     command_seq ++ " " ++ cmd.command_name,
+                    max_line_len,
                     trailing_handler,
                 );
                 flags.command = @unionInit(

--- a/src/help.zig
+++ b/src/help.zig
@@ -34,7 +34,13 @@ const Section = struct {
                 const base_indent: usize = indent.len + section.max_name_len;
                 comptime var col: usize = base_indent;
                 comptime var words = std.mem.tokenize(u8, description, " \r\n");
-                inline while (words.next()) |word| {
+
+                // The branches here add up quickly; the limit must be increased for any
+                // reasonably-sized descriptions Note that the default is 1000.
+                // This may increase compilation times, but if that was a concern, you'd
+                // be using a different library.
+                @setEvalBranchQuota(100000);
+                while (words.next()) |word| {
                     if (col + word.len > section.max_line_len) {
                         str = str ++ "\n" ++ indent ** 2 ++ " " ** (section.max_name_len);
                         col = base_indent - 1;

--- a/src/help.zig
+++ b/src/help.zig
@@ -2,9 +2,9 @@ const std = @import("std");
 const meta = @import("meta.zig");
 const cons = @import("console.zig");
 
-const fmt_green_bold: []const u8 = cons.ansi ++ cons.fg_green ++ cons.text_bold;
-const fmt_white_bold: []const u8 = cons.ansi ++ cons.fg_white ++ cons.text_bold;
-const fmt_magenta_bold: []const u8 = cons.ansi ++ cons.fg_magenta ++ cons.text_bold;
+const fmt_green_bold: []const u8 = cons.fg_green ++ cons.text_bold;
+const fmt_white_bold: []const u8 = cons.fg_white ++ cons.text_bold;
+const fmt_magenta_bold: []const u8 = cons.fg_magenta ++ cons.text_bold;
 
 /// A help section with a heading and a list of items.
 const Section = struct {
@@ -154,14 +154,16 @@ const Usage = struct {
 
     pub fn render(self: Usage, comptime command_seq: []const u8) []const u8 {
         var usage: []const u8 = fmt_green_bold ++ "Usage: " ++ cons.ansi_end ++ command_seq;
+        const ansi_codes_len = fmt_green_bold.len + cons.ansi_end.len;
 
-        const indent_len = usage.len;
+        const indent_len = usage.len - ansi_codes_len;
         const max_line_len = 80;
         var len_prev_lines = 0;
 
         for (self.items) |item| {
-            if (usage.len + " ".len + item.len - len_prev_lines > max_line_len) {
-                len_prev_lines = usage.len;
+            const cur_len = usage.len - ansi_codes_len;
+            if (cur_len + " ".len + item.len - len_prev_lines > max_line_len) {
+                len_prev_lines = cur_len;
                 usage = usage ++ "\n" ++ " " ** indent_len;
             }
             usage = usage ++ " " ++ item;

--- a/src/help.zig
+++ b/src/help.zig
@@ -313,8 +313,8 @@ test generate {
     {
         const help_usage = fmt_green_bold ++ "Usage: " ++ cons.ansi_end;
         comptime var usage_str: []const u8 =
-            \\test [-f | --force] [-t | --target <target>]
-            \\                         --choice <choice> <FILE> <command>
+            \\test [-f | --force] [-t | --target <target>] --choice <choice> <FILE>
+            \\            <command>
             \\
             \\
         ;

--- a/src/meta.zig
+++ b/src/meta.zig
@@ -126,6 +126,25 @@ pub fn info(comptime Flags: type) FlagsInfo {
     return command;
 }
 
+// Converts Type name "namespace.MyCommand" to "my-command"
+pub fn commandName(comptime Command: type) []const u8 {
+    comptime var base_name: []const u8 = @typeName(Command);
+    // Trim off the leading namespaces - separated by dots.
+    if (std.mem.lastIndexOfScalar(u8, base_name, '.')) |last_dot_idx| {
+        base_name = base_name[last_dot_idx + 1 ..];
+    }
+
+    comptime var cmd_name: []const u8 = &.{std.ascii.toLower(base_name[0])};
+    for (base_name[1..]) |ch| {
+        cmd_name = cmd_name ++ if (std.ascii.isUpper(ch))
+            .{ '-', std.ascii.toLower(ch) }
+        else
+            .{ch};
+    }
+
+    return cmd_name;
+}
+
 pub fn compileError(comptime fmt: []const u8, args: anytype) void {
     @compileError("(flags) " ++ std.fmt.comptimePrint(fmt, args));
 }

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -15,6 +15,8 @@ pub const ParseOptions = struct {
     /// The name of the command used to run the program, should be your executable name.
     /// If omitted, the name of the Command type will be used.
     command_name: ?[]const u8 = null,
+    /// The maximum line length (in characters) to wrap long descriptions at
+    max_line_len: usize = 80,
 };
 
 /// A TrailingHandler that causes a printError error when a trailing argument is passed.
@@ -175,10 +177,10 @@ pub fn parseWithTrailingHandler(
     if (options.skip_first_arg) {
         if (!args.skip()) {
             printError("expected at least 1 argument", .{});
-            try help.printUsage(Command, command_name, std.io.getStdOut().writer());
+            try help.printUsage(Command, command_name, options.max_line_len, std.io.getStdOut().writer());
             return error.NoArguments;
         }
     }
 
-    return core.parse(args, Command, command_name, trailing_handler);
+    return core.parse(args, Command, command_name, options.max_line_len, trailing_handler);
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,9 +1,7 @@
-const std = @import("std");
 const parser = @import("parser.zig");
-const help = @import("help.zig");
+pub const help = @import("help.zig");
 
-pub usingnamespace parser;
-// pub const helpMessage = help.helpMessage;
+pub usingnamespace @import("parser.zig");
 
 test {
     _ = help;


### PR DESCRIPTION
# Summary

In order to play nicely with users, don't crash on error; instead return an error value and allow the caller to handle.

If an error does occur while parsing the arguments, print a helpful error message then also print the usage text.

# Changes

## Add ANSI console helper functions

For pretty-printing, some simple console utilities for printing styled text to the terminal using ANSI codes were added.  Only a few pieces of this new `console.zig` are currently used; I can absolutely remove everything that's not currently in use if desired - it's mostly just a copy-paste from one of my own projects.

## Export 'help' to the pubilc module

Allows users to print the usage message on their own if they want to:

```zig
const stdout = std.io.getStdOut().writer();
flags.help.printUsage(MyFlagsStruct, null, stdout) catch unreachable;
```

## Don't crash upon error

Most library users don't want a library to crash their program upon an error. Instead, an error should be propagated up for the user to handle how they like.

# Sample Usage

I integrated this with my [markdown parser/renderer project](https://github.com/JacobCrabill/zigdown). It's working great!

Current usage:

```zig
var args = try std.process.argsWithAllocator(alloc);
defer args.deinit();
const result = flags.parse(&args, Zigdown, .{}) catch std.process.exit(1);
```

![image](https://github.com/user-attachments/assets/59a2224e-3e09-454a-80d6-657a9f2c5a2f)
