### PR TITLE
upgrade to zig 0.15.1

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -15,8 +15,7 @@ pub fn build(b: *std.Build) void {
     const tests_step = b.step("test", "Run tests");
 
     const tests = b.addTest(.{
-        .root_source_file = root,
-        .target = target,
+        .root_module = mod,
     });
 
     const tests_run = b.addRunArtifact(tests);
@@ -34,11 +33,15 @@ pub fn build(b: *std.Build) void {
         "Example to run for example step (default = overview)",
     ) orelse .overview;
 
-    const example = b.addExecutable(.{
-        .name = "example",
+    const example_module = b.createModule(.{
         .root_source_file = b.path(b.fmt("examples/{s}.zig", .{@tagName(example_option)})),
         .target = target,
         .optimize = optimize,
+    });
+
+    const example = b.addExecutable(.{
+        .name = "example",
+        .root_module = example_module,
     });
     example.root_module.addImport("flags", mod);
     const run_example = b.addRunArtifact(example);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .flags,
     .version = "0.10.0",
     .fingerprint = 0xb0541bade61ff6b,
-    .minimum_zig_version = "0.14.0-dev.2802+257054a14",
+    .minimum_zig_version = "0.15.1",
     // Want to limit these to only the things that really constitute "the library".
     // The hash needn't be updated by some small change to the README.
     .paths = .{

--- a/examples/overview.zig
+++ b/examples/overview.zig
@@ -10,11 +10,14 @@ pub fn main() !void {
 
     const options = flags.parse(args, "overview", Flags, .{});
 
-    try std.json.stringify(
+    var buffer: [1024]u8 = undefined;
+    var file_writer = std.fs.File.stdout().writer(&buffer);
+    try std.json.Stringify.value(
         options,
         .{ .whitespace = .indent_2 },
-        std.io.getStdOut().writer(),
+        &file_writer.interface,
     );
+    try file_writer.interface.flush();
 }
 
 const Flags = struct {

--- a/examples/trailing.zig
+++ b/examples/trailing.zig
@@ -10,10 +10,11 @@ pub fn main() !void {
 
     const options = flags.parse(args, "trailing", Flags, .{});
 
-    try std.json.stringify(
+    var stdout_writer = std.fs.File.stdout().writer(&.{});
+    try std.json.Stringify.value(
         options,
         .{ .whitespace = .indent_2 },
-        std.io.getStdOut().writer(),
+        &stdout_writer.interface,
     );
 }
 

--- a/src/Help.zig
+++ b/src/Help.zig
@@ -18,7 +18,8 @@ pub const Usage = struct {
     body: []const u8,
 
     pub fn render(usage: Usage, stdout: File, colors: *const ColorScheme) void {
-        const term = Terminal.init(stdout);
+        var stdout_writer = stdout.writer(&.{});
+        const term = Terminal.init(stdout, &stdout_writer.interface);
         usage.renderToTerminal(term, colors);
     }
 
@@ -100,7 +101,8 @@ const Section = struct {
 };
 
 pub fn render(help: *const Help, stdout: File, colors: *const ColorScheme) void {
-    const term = Terminal.init(stdout);
+    var stdout_writer = stdout.writer(&.{});
+    const term = Terminal.init(stdout, &stdout_writer.interface);
     help.usage.renderToTerminal(term, colors);
 
     if (help.description) |description| {
@@ -181,7 +183,7 @@ pub fn generate(Flags: type, info: meta.FlagsInfo, command: []const u8) Help {
     help.sections = help.sections ++ .{options};
 
     if (info.positionals.len > 0) {
-        const pos_descriptions = meta.getDescriptions(std.meta.FieldType(Flags, .positional));
+        const pos_descriptions = meta.getDescriptions(@FieldType(Flags, "positional"));
         var arguments = Section{ .header = "Arguments:" };
         for (info.positionals) |arg| {
             arguments.add(.{
@@ -203,7 +205,7 @@ pub fn generate(Flags: type, info: meta.FlagsInfo, command: []const u8) Help {
         help.sections = help.sections ++ .{arguments};
     }
     if (info.subcommands.len > 0) {
-        const cmd_descriptions = meta.getDescriptions(std.meta.FieldType(Flags, .command));
+        const cmd_descriptions = meta.getDescriptions(@FieldType(Flags, "command"));
         var commands = Section{ .header = "Commands:" };
         for (info.subcommands) |cmd| commands.add(.{
             .name = cmd.command_name,

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -15,7 +15,9 @@ current_arg: usize,
 colors: *const ColorScheme,
 
 fn fatal(parser: *const Parser, comptime fmt: []const u8, args: anytype) noreturn {
-    const stderr = Terminal.init(std.io.getStdErr());
+    const stderr_file = std.fs.File.stderr();
+    var stderr_file_writer = stderr_file.writer(&.{});
+    const stderr = Terminal.init(stderr_file, &stderr_file_writer.interface);
     stderr.print(parser.colors.error_label, "Error: ", .{});
     stderr.print(parser.colors.error_message, fmt ++ "\n", args);
     std.process.exit(1);
@@ -41,7 +43,7 @@ pub fn parse(parser: *Parser, Flags: type, comptime command_name: []const u8) Fl
         }
 
         if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
-            help.render(std.io.getStdOut(), parser.colors);
+            help.render(std.fs.File.stdout(), parser.colors);
             std.process.exit(0);
         }
 

--- a/src/Terminal.zig
+++ b/src/Terminal.zig
@@ -6,12 +6,12 @@ const ColorScheme = @import("ColorScheme.zig");
 const tty = std.io.tty;
 const File = std.fs.File;
 
-writer: File.Writer,
+writer: *std.Io.Writer,
 config: tty.Config,
 
-pub fn init(file: File) Terminal {
+pub fn init(file: File, writer: *std.Io.Writer) Terminal {
     return .{
-        .writer = file.writer(),
+        .writer = writer,
         .config = tty.detectConfig(file),
     };
 }


### PR DESCRIPTION
Did the bare minimum to get the project working again with zig 0.15.1.

Verification evidence:

- unit tests pass
- all examples compile and run

```
$ zig build test
(pass)
$ zig build run-example -Dexample=trailing -- --some-flag 2
{
  "some_flag": true,
  "positional": {
    "some_number": 2,
    "maybe_number": null,
    "trailing": []
  }
}
$ zig build run-example -Dexample=colors -- -h
Usage: colors [--foo] --bar <bar> [-h | --help]

Showcase of terminal color options.

Options:

  --foo
  --bar
  -h, --help Show this help and exit
$ zig build run-example -Dexample=overview -- -h
Usage: overview [-f | --force] [--optional <optional>] [--override <override>]
                --required <required> [-a | --age <age>] [-p | --power <power>]
                [-s | --size <size>] [-h | --help] <FIRST> <SECOND> [<THIRD>]
                <command>

This is a dummy command for testing purposes.
There are a bunch of options for demonstration purposes.

Options:

  -f, --force Use the force
  --optional  You don't need this one
  --override  You can change this if you want
  --required  You have to set this!
  -a, --age   How old?
  -p, --power How strong?
  -s, --size  How big?
    small     The least big
    medium    Not quite small, not quite big
    large     The biggest
  -h, --help  Show this help and exit

Arguments:

  <FIRST>  The first argument (required)
  <SECOND> The second argument (required)
  <THIRD>  The third argument (optional)

Commands:

  frobnicate  Frobnicate everywhere
  defrabulise Defrabulise everyone
```

And here is proof that colors still work:

<img width="680" height="761" alt="image" src="https://github.com/user-attachments/assets/e3196dd8-c0f4-4e3b-9031-068463d1c4b5" />

