### PR TITLE
fix import of std.Io

### DIFF
--- a/src/ColorScheme.zig
+++ b/src/ColorScheme.zig
@@ -2,7 +2,7 @@ const ColorScheme = @This();
 
 const std = @import("std");
 
-const Color = std.io.tty.Color;
+const Color = std.Io.tty.Color;
 
 pub const Style = []const Color;
 

--- a/src/Terminal.zig
+++ b/src/Terminal.zig
@@ -3,7 +3,7 @@ const Terminal = @This();
 const std = @import("std");
 const ColorScheme = @import("ColorScheme.zig");
 
-const tty = std.io.tty;
+const tty = std.Io.tty;
 const File = std.fs.File;
 
 writer: *std.Io.Writer,


### PR DESCRIPTION
`std.io` is in the 'deprecated' section of Zig 0.15.1's [std.zig](https://github.com/ziglang/zig/blob/3db960767d12b6214bcf43f1966a037c7a586a12/lib/std/std.zig#L82)